### PR TITLE
8 feature separate database for guild data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 .env
 config.json
 playerData.json
+guildData.json
 .replit

--- a/cogs/background/background.py
+++ b/cogs/background/background.py
@@ -30,17 +30,17 @@ class Background(commands.Cog):
     @tasks.loop(seconds=30)
     async def valorant_watch_cycle(self):
         await self.bot.wait_until_ready()  # wait until the bot logs in
-        channel = self.bot.get_channel(
-            config["watch_channel"]
-        )  # retrieves channel ID from config.json
         player_data = json_helper.load("playerData.json")
         for user_id in player_data:
             player_data = json_helper.load("playerData.json")  # reloads player_data
+            guild_data = json_helper.load("guildData.json")
             user_data = player_data[user_id]
             if time.time() - user_data["lastTime"] < config["watch_cooldown"] * 60:
                 continue  # cooldown in seconds
             puuid = user_data["puuid"]
             region = user_data["region"]
+            guild = user_data["guild"]
+            channel = self.bot.get_channel(guild_data[guild]["watch_channel"])
             async with aiohttp.ClientSession() as session:
                 async with session.get(
                     f"https://api.henrikdev.xyz/valorant/v3/by-puuid/matches/{region}/{puuid}"
@@ -76,7 +76,8 @@ class Background(commands.Cog):
                         for player_id in player_data:
                             if (
                                 player["puuid"] == player_data[player_id]["puuid"]
-                            ):  # detects if multiple watched users are in the same game
+                                and player_data[player_id]["guild"] == guild
+                            ):  # detects if multiple watched users who "watched" in the same guild are in the same game
                                 kills = player["stats"]["kills"]
                                 deaths = player["stats"]["deaths"]
                                 assists = player["stats"]["assists"]

--- a/cogs/background/background.py
+++ b/cogs/background/background.py
@@ -33,9 +33,9 @@ class Background(commands.Cog):
         channel = self.bot.get_channel(
             config["watch_channel"]
         )  # retrieves channel ID from config.json
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         for user_id in player_data:
-            player_data = json_helper.load()  # reloads player_data
+            player_data = json_helper.load("playerData.json")  # reloads player_data
             user_data = player_data[user_id]
             if time.time() - user_data["lastTime"] < config["watch_cooldown"] * 60:
                 continue  # cooldown in seconds
@@ -163,7 +163,7 @@ class Background(commands.Cog):
                             f"<@{'> <@'.join(list(set(combined_waiters)))}> removing from waitlist"
                         )  # pings waiters
 
-                    json_helper.save(player_data)
+                    json_helper.save(player_data, "playerData.json")
             await asyncio.sleep(0.5)  # sleeps for number of seconds (avoid rate limit)
 
 

--- a/cogs/contextmenu/contextmenu.py
+++ b/cogs/contextmenu/contextmenu.py
@@ -32,7 +32,7 @@ class ContextMenu(commands.Cog):
     ):
         await inter.response.defer()
         """pings you when tagged user is done"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         wait_user_id = str(wait_user.id)
         inter_user_id = str(inter.user.id)
         extra_message = ""

--- a/cogs/error/error.py
+++ b/cogs/error/error.py
@@ -20,6 +20,8 @@ class ErrorHandler(commands.Cog):
             message = "You are missing the required permissions to run this command!"
         elif isinstance(error, commands.UserInputError):
             message = "Something about your input was wrong, please check your input and try again!"
+        elif isinstance(error, commands.NoPrivateMessage):
+            message = "This command cannot be run in a Private Message!"
         else:
             message = "Oh no! Something went wrong while running the command!"
 

--- a/cogs/prefix/game-prefix.py
+++ b/cogs/prefix/game-prefix.py
@@ -30,6 +30,21 @@ class Game(commands.Cog, name="game"):
         )
 
     @commands.command(
+        name="valorant-setchannel",
+        aliases=["valorantsetchannel", "valsetchannel", "vsetchannel","vset"],
+        description="set the channel the bot will send updates to",
+    )
+    @commands.has_guild_permissions(manage_messages=True)
+    async def valorant_setchannel(self, ctx: commands.Context):
+        """set the channel the bot will send updates to"""
+        channel = ctx.channel
+        guild = ctx.guild
+        guild_data = json_helper.load("guildData.json")
+        guild_data[str(guild.id)]["watch_channel"] = channel.id
+        json_helper.save(guild_data, "guildData.json")
+        await ctx.send(f"Successfully set {channel} as watch channel for {guild}")
+
+    @commands.command(
         name="valorant-info",
         aliases=["valorantinfo", "valinfo", "vinfo"],
         description="view valorant data in database",

--- a/cogs/prefix/game-prefix.py
+++ b/cogs/prefix/game-prefix.py
@@ -31,7 +31,7 @@ class Game(commands.Cog, name="game"):
 
     @commands.command(
         name="valorant-setchannel",
-        aliases=["valorantsetchannel", "valsetchannel", "vsetchannel","vset"],
+        aliases=["valorantsetchannel", "valsetchannel", "vsetchannel", "vset"],
         description="set the channel the bot will send updates to",
     )
     @commands.has_guild_permissions(manage_messages=True)
@@ -42,7 +42,7 @@ class Game(commands.Cog, name="game"):
         guild_data = json_helper.load("guildData.json")
         guild_data[str(guild.id)]["watch_channel"] = channel.id
         json_helper.save(guild_data, "guildData.json")
-        await ctx.send(f"Successfully set {channel} as watch channel for {guild}")
+        await ctx.send(f"Successfully set `#{channel}` as watch channel for `{guild}`")
 
     @commands.command(
         name="valorant-info",
@@ -79,6 +79,19 @@ class Game(commands.Cog, name="game"):
     )
     async def valorant_watch(self, ctx: commands.Context, name: str, tag: str):
         """add user's valorant info to the database"""
+        if isinstance(ctx.channel, disnake.channel.DMChannel):
+            guild_id = 0
+        else:
+            guild_data = json_helper.load("guildData.json")
+            guild_id = ctx.guild.id
+            if (
+                str(guild_id) not in guild_data
+                or guild_data[str(guild_id)]["watch_channel"] == 0
+            ):
+                await ctx.send(
+                    "Please set the watch channel for the guild first using valorant-setchannel! You can also DM me and I will DM you for each update instead!"
+                )
+                return
         player_data = json_helper.load("playerData.json")
         user_id = str(ctx.author.id)
         async with aiohttp.ClientSession() as session:
@@ -95,6 +108,7 @@ class Game(commands.Cog, name="game"):
                         "puuid": data["data"]["puuid"],
                         "lastTime": time.time(),
                         "streak": 0,
+                        "guild": guild_id,
                     }
                     await ctx.send(
                         content=f"<@{user_id}> database updated, user added. remove using /valorant-unwatch"

--- a/cogs/prefix/game-prefix.py
+++ b/cogs/prefix/game-prefix.py
@@ -36,7 +36,7 @@ class Game(commands.Cog, name="game"):
     )
     async def valorant_info(self, ctx: commands.Context):
         """returns user's valorant info from the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(ctx.author.id)
         if user_id in player_data:
             user_data = player_data[user_id]
@@ -62,7 +62,7 @@ class Game(commands.Cog, name="game"):
     )
     async def valorant_watch(self, ctx: commands.Context, name: str, tag: str):
         """add user's valorant info to the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(ctx.author.id)
         async with aiohttp.ClientSession() as session:
             async with session.get(
@@ -81,7 +81,7 @@ class Game(commands.Cog, name="game"):
                     await ctx.send(
                         content=f"<@{user_id}> database updated, user added. remove using /valorant-unwatch"
                     )
-                    json_helper.save(player_data)
+                    json_helper.save(player_data, "playerData.json")
                 else:
                     await ctx.send(
                         content=f"<@{user_id}> error connecting, database not updated. please try again"
@@ -102,11 +102,11 @@ class Game(commands.Cog, name="game"):
     )
     async def valorant_unwatch(self, ctx: commands.Context):
         """removes user's valorant info from the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(ctx.author.id)
         if user_id in player_data:
             del player_data[user_id]
-            json_helper.save(player_data)
+            json_helper.save(player_data, "playerData.json")
             await ctx.send(
                 content=f"<@{user_id}> database updated, user removed. add again using /valorant-watch"
             )
@@ -120,7 +120,7 @@ class Game(commands.Cog, name="game"):
     )
     async def valorant_wait(self, ctx: commands.Context, wait_user: disnake.User):
         """pings you when tagged user is done"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         wait_user_id = str(wait_user.id)
         inter_user_id = str(ctx.author.id)
         extra_message = ""

--- a/cogs/slash/game-slash.py
+++ b/cogs/slash/game-slash.py
@@ -30,6 +30,23 @@ class Game(commands.Cog):
         )
 
     @commands.slash_command(
+        name="valorant-setchannel",
+        description="set the channel the bot will send updates to",
+    )
+    @commands.has_guild_permissions(manage_messages=True)
+    async def valorant_setchannel(self, inter: disnake.ApplicationCommandInteraction):
+        await inter.response.defer()
+        """set the channel the bot will send updates to"""
+        channel = inter.channel
+        guild = inter.guild
+        guild_data = json_helper.load("guildData.json")
+        guild_data[str(guild.id)]["watch_channel"] = channel.id
+        json_helper.save(guild_data, "guildData.json")
+        await inter.edit_original_message(
+            content=f"Successfully set `#{channel}` as watch channel for `{guild}`"
+        )
+
+    @commands.slash_command(
         name="valorant-info", description="view valorant data in database"
     )
     async def valorant_info(
@@ -62,7 +79,18 @@ class Game(commands.Cog):
         name="valorant-watch", description="adds user into database"
     )
     async def valorant_watch(self, inter: disnake.ApplicationCommandInteraction):
-        await inter.response.send_modal(modal=ValorantWatchModal())
+        guild_data = json_helper.load("guildData.json")
+        guild_id = inter.guild_id
+        if (
+            str(guild_id) not in guild_data
+            or guild_data[str(guild_id)]["watch_channel"] == 0
+        ):
+            await inter.send(
+                content="Please set the watch channel for the guild first using valorant-setchannel! You can also DM me and I will DM you for each update instead!"
+            )
+            return
+        else:
+            await inter.response.send_modal(modal=ValorantWatchModal())
 
     @commands.slash_command(
         name="valorant-unwatch",

--- a/cogs/slash/game-slash.py
+++ b/cogs/slash/game-slash.py
@@ -35,7 +35,7 @@ class Game(commands.Cog):
     async def valorant_info(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()
         """returns user's valorant info from the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(inter.user.id)
         if user_id in player_data:
             user_data = player_data[user_id]
@@ -67,11 +67,11 @@ class Game(commands.Cog):
     async def valorant_unwatch(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()
         """removes user's valorant info from the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(inter.user.id)
         if user_id in player_data:
             del player_data[user_id]
-            json_helper.save(player_data)
+            json_helper.save(player_data, "playerData.json")
             await inter.edit_original_message(
                 content=f"<@{user_id}> database updated, user removed. add again using /valorant-watch"
             )
@@ -88,7 +88,7 @@ class Game(commands.Cog):
     ):
         await inter.response.defer()
         """pings you when tagged user is done"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         wait_user_id = str(wait_user.id)
         inter_user_id = str(inter.user.id)
         extra_message = ""

--- a/helpers/json_helper.py
+++ b/helpers/json_helper.py
@@ -2,16 +2,16 @@ import os
 import json
 
 
-def load() -> None:
-    if not os.path.isfile("playerData.json"):
-        print("'playerData.json' not found, using empty data...")
+def load(filename) -> None:
+    if not os.path.isfile(filename):
+        print(f"'{filename}' not found, using empty data...")
         return {}
     else:
-        with open("playerData.json", encoding="utf-8") as file:
+        with open(filename, encoding="utf-8") as file:
             return json.load(file)
 
 
-def save(data) -> None:
-    with open("playerData.json", "w", encoding="utf-8") as file:
+def save(data, filename) -> None:
+    with open(filename, "w", encoding="utf-8") as file:
         file.seek(0)
         json.dump(data, file, indent=4)

--- a/modals/modals.py
+++ b/modals/modals.py
@@ -31,6 +31,8 @@ class ValorantWatchModal(disnake.ui.Modal):
     async def callback(self, inter: disnake.ModalInteraction) -> None:
         await inter.response.defer()
         """add user's valorant info to the database"""
+        guild_data = json_helper.load("guildData.json")
+        guild_id = inter.guild_id
         player_data = json_helper.load("playerData.json")
         user_id = str(inter.user.id)
         name = inter.text_values["name"]
@@ -49,6 +51,7 @@ class ValorantWatchModal(disnake.ui.Modal):
                         "puuid": data["data"]["puuid"],
                         "lastTime": time.time(),
                         "streak": 0,
+                        "guild": guild_id,
                     }
                     await inter.edit_original_message(
                         content=f"<@{user_id}> database updated, user added. remove using /valorant-unwatch"

--- a/modals/modals.py
+++ b/modals/modals.py
@@ -31,7 +31,7 @@ class valorant_watch_modal(disnake.ui.Modal):
     async def callback(self, inter: disnake.ModalInteraction) -> None:
         await inter.response.defer()
         """add user's valorant info to the database"""
-        player_data = json_helper.load()
+        player_data = json_helper.load("playerData.json")
         user_id = str(inter.user.id)
         name = inter.text_values["name"]
         tag = inter.text_values["tag"]
@@ -52,7 +52,7 @@ class valorant_watch_modal(disnake.ui.Modal):
                     await inter.edit_original_message(
                         content=f"<@{user_id}> database updated, user added. remove using /valorant-unwatch"
                     )
-                    json_helper.save(player_data)
+                    json_helper.save(player_data, "playerData.json")
                 else:
                     await inter.edit_original_message(
                         content=f"<@{user_id}> error connecting, database not updated. please try again"


### PR DESCRIPTION
valorant-setchannel
- set the channel the bot will send updates into

valorant-watch
- if channel of guild not set, will send message requesting for channel to be set first
- if PM, guild = 0

background
- checks if user still exists
- checks if bot is still in guild or if guild still exists
- checks if channel is still in guild